### PR TITLE
Open interval

### DIFF
--- a/R/life-tables.R
+++ b/R/life-tables.R
@@ -151,7 +151,7 @@ lt_2015 <- d |>
 # Create Table 2
 library(kableExtra)
 lt_2015 |>
-  select(Age = age, x, n, Mx, ax, qx, px, lx, dx, Lx, Tx, ex) %>%
+  select(Age = age, x, n, Mx, ax, qx, px, lx, dx, Lx, Tx, ex) |>
   kable(format = "latex", booktabs = T,
         digits = c(NA, 0, 0, 6, 3, 6, 6, 6, 6, 3, 3, 3))
 

--- a/R/life-tables.R
+++ b/R/life-tables.R
@@ -248,6 +248,6 @@ clt |>
   mutate(Mx = dx/Lx) |>
   mutate(px = 1-qx) |>
   mutate(Tx = rev(cumsum(rev(Lx)))) |>
-  mutate(ex = Tx / lx) %>% View()
+  mutate(ex = Tx / lx)
 
 


### PR DESCRIPTION
This PR does the following for the period life table example:

1. Starts with deaths and population instead of Mx
2. Aggregates oldest age groups to a 95+ open age interval
3. Modifies ax, qx, Lx computation for open age interval
4. Adds `kable()` function call to create Table 2